### PR TITLE
调整深色模式播放页“接下来播放”（ #reco_list > div.next-play ）的颜色

### DIFF
--- a/src/js/modules/darkMode/UI/pageVideo.js
+++ b/src/js/modules/darkMode/UI/pageVideo.js
@@ -437,7 +437,7 @@ const VideoPlayDarkModeStyle = createGlobalStyle`
       .rec-title {
         color: var(--dark-font-3);
       }
-      .rec-list .card-box {
+      .card-box {
         .pic-box {
           background: var(--dark-1)!important;
         }


### PR DESCRIPTION
在pull之前请确认您已经完成的阅览本项目的文档、手册或开发指导意见书 [Document](./docs/main.md)，并在编码过程中遵循了其中的约定。

请确认如下两点，如若满足我们将考虑对您的pull进行采纳。

- [x] 我已经充分阅览本项目的文档、手册或开发指导意见书，并在编码过程中遵循了其中的约定。
- [x] 我对提交的代码有充分的了解，并且已经明确标注了有关的参考来源。

最后，请描述该pull的具体作用或需要特殊说明的细节：

<br>

你好！

最初我想复制一份`.rec-list`的样式，如下：

```css
.next-play .card-box {
    .pic-box {
        background: var(--dark-1)!important;
    }
    .info .title {
        color: var(--dark-font-3);
    }
}
```

经测试，我认为可以仅使用`.card-box`来选择所有的视频卡片元素，于是移除了`.rec-list`选择器，以减少看上去重复的代码。

效果对比如下图（登录状态）：

![comparison](https://user-images.githubusercontent.com/29089388/99637564-00a62100-2a80-11eb-9c36-6942a0927fd6.png)

我没有一并处理类名为`.vcd`的广告的颜色问题（`#app > div.v-wrap > div.r-con > a > div.vcd`）。该广告位于“相关推荐”、“更多视频推荐”或“接下来播放”（`#reco_list`）的上方（也在上图中），不过它并不总是出现。

值得一提的是，在目前的网站中，如果没有登录账号，*似乎*就不会显示“接下来播放”（`#reco_list > div.next-play`）这个元素。

<br>

请测试我的修改，谢谢。
