### PR TITLE
深色模式 消息中心的消息设置（ .config .config-item ）的单选按钮（ label.type-selector.radio-selector ）的文字颜色

### DIFF
--- a/src/js/modules/darkMode/UI/pageMessage.js
+++ b/src/js/modules/darkMode/UI/pageMessage.js
@@ -289,7 +289,7 @@ const MessageDarkModeStyle = createGlobalStyle`
             &::before {
               background: var(--dark-1)!important;
             }
-            label.type-selector.radio-selector {
+            .radio-selector {
               color: var(--dark-font-0);
             }
           }

--- a/src/js/modules/darkMode/UI/pageMessage.js
+++ b/src/js/modules/darkMode/UI/pageMessage.js
@@ -289,6 +289,9 @@ const MessageDarkModeStyle = createGlobalStyle`
             &::before {
               background: var(--dark-1)!important;
             }
+            label.type-selector.radio-selector {
+              color: var(--dark-font-0);
+            }
           }
         }
       }


### PR DESCRIPTION
在pull之前请确认您已经完成的阅览本项目的文档、手册或开发指导意见书 [Document](./docs/main.md)，并在编码过程中遵循了其中的约定。

请确认如下两点，如若满足我们将考虑对您的pull进行采纳。

- [x] 我已经充分阅览本项目的文档、手册或开发指导意见书，并在编码过程中遵循了其中的约定。
- [x] 我对提交的代码有充分的了解，并且已经明确标注了有关的参考来源。

最后，请描述该pull的具体作用或需要特殊说明的细节：

<br>

你好！

效果对比如下图：

![comparison](https://user-images.githubusercontent.com/29089388/103358237-12073200-4af0-11eb-97b8-5b122d294a8e.png)

<br>

请测试我的修改，谢谢。